### PR TITLE
fix cross-compile

### DIFF
--- a/scripts/src/osd/newui.lua
+++ b/scripts/src/osd/newui.lua
@@ -40,11 +40,15 @@ function maintargetosdoptions(_target,_subtarget)
 		"ole32",
 	}
 
+	includedirs {
+		MAME_DIR .. "src/osd/winui/res"
+	}
+
 -- needs same resources as messui, because dropdown menus are in mameui.rc
 	override_resources = true;
-	rctarget = _subtarget;
-	local rcfile = MAME_DIR .. "src/osd/winui/" .. _subtarget .. ".rc"
-	local uifile = MAME_DIR .. "src/osd/winui/" .. _subtarget .. "ui.rc"
+	rctarget = _target;
+	local rcfile = MAME_DIR .. "src/osd/winui/" .. _target .. ".rc"
+	local uifile = MAME_DIR .. "src/osd/winui/" .. _target .. "ui.rc"
 
 	if not os.isfile(rcfile) then
 		print(string.format("***** %s not found *****",rcfile))

--- a/scripts/src/osd/winui.lua
+++ b/scripts/src/osd/winui.lua
@@ -62,6 +62,10 @@ function maintargetosdoptions(_target,_subtarget)
 		"ole32",
 	}
 
+	includedirs {
+		MAME_DIR .. "src/osd/winui/res"
+	}
+
 -- Local file gives correct icon in mame instance inside of mameui
 -- Local file must #include mameui.rc
 	override_resources = true;

--- a/src/osd/winui/hbmame.rc
+++ b/src/osd/winui/hbmame.rc
@@ -14,7 +14,7 @@ LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 // Icon
 //
 
-2           ICON    DISCARDABLE     "res\\hbmame.ico"
+2           ICON    DISCARDABLE     "hbmame.ico"
 #endif    // English (U.S.) resources
 
 #include "hbmameui.rc"

--- a/src/osd/winui/hbmameui.rc
+++ b/src/osd/winui/hbmameui.rc
@@ -340,36 +340,36 @@ END
 
 // Icon with lowest ID value placed first to ensure application icon
 // remains consistent on all systems.
-IDI_MAMEUI_ICON         ICON                    "res\\hbmameui.ico"
-IDI_WIN_ROMS            ICON                    "res\\win_roms.ico"
-IDI_WIN_NOROMS          ICON                    "res\\win_noro.ico"
-IDI_WIN_UNKNOWN         ICON                    "res\\win_unkn.ico"
-IDI_WIN_CLONE           ICON                    "res\\win_clone.ico"
-IDI_WIN_REDX            ICON                    "res\\win_redx.ico"
-IDI_FOLDER_AVAILABLE    ICON                    "res\\foldavail.ico"
-IDI_FOLDER              ICON                    "res\\folder.ico"
-IDI_FOLDER_MANUFACTURER ICON                    "res\\foldmanu.ico"
-IDI_FOLDER_OPEN         ICON                    "res\\foldopen.ico"
-IDI_FOLDER_UNAVAILABLE  ICON                    "res\\foldunav.ico"
-IDI_FOLDER_HORIZONTAL   ICON                    "res\\horz.ico"
-IDI_FOLDER_VERTICAL     ICON                    "res\\vert.ico"
-IDI_MANUFACTURER        ICON                    "res\\manufact.ico"
-IDI_FOLDER_YEAR         ICON                    "res\\foldyear.ico"
-IDI_FOLDER_SOURCE       ICON                    "res\\foldsrc.ico"
-IDI_WORKING             ICON                    "res\\working.ico"
-IDI_NONWORKING          ICON                    "res\\nonwork.ico"
-IDI_YEAR                ICON                    "res\\year.ico"
-IDI_KEYBOARD            ICON                    "res\\keyboard.ico"
-IDI_JOYSTICK            ICON                    "res\\joystick.ico"
-IDI_CPU                 ICON                    "res\\cpu.ico"
-IDI_SOUND               ICON                    "res\\samples.ico"
-IDI_SOUNDTAB            ICON                    "res\\sound.ico"
-IDI_SOURCE              ICON                    "res\\source.ico"
-IDI_HARDDISK            ICON                    "res\\harddisk.ico"
-IDI_DISPLAY             ICON                    "res\\display.ico"
-IDI_CHECKMARK           ICON                    "res\\checkmark.ico"
-IDI_HEADER_UP           ICON                    "res\\header_up.ico"
-IDI_HEADER_DOWN         ICON                    "res\\header_down.ico"
+IDI_MAMEUI_ICON         ICON                    "hbmameui.ico"
+IDI_WIN_ROMS            ICON                    "win_roms.ico"
+IDI_WIN_NOROMS          ICON                    "win_noro.ico"
+IDI_WIN_UNKNOWN         ICON                    "win_unkn.ico"
+IDI_WIN_CLONE           ICON                    "win_clone.ico"
+IDI_WIN_REDX            ICON                    "win_redx.ico"
+IDI_FOLDER_AVAILABLE    ICON                    "foldavail.ico"
+IDI_FOLDER              ICON                    "folder.ico"
+IDI_FOLDER_MANUFACTURER ICON                    "foldmanu.ico"
+IDI_FOLDER_OPEN         ICON                    "foldopen.ico"
+IDI_FOLDER_UNAVAILABLE  ICON                    "foldunav.ico"
+IDI_FOLDER_HORIZONTAL   ICON                    "horz.ico"
+IDI_FOLDER_VERTICAL     ICON                    "vert.ico"
+IDI_MANUFACTURER        ICON                    "manufact.ico"
+IDI_FOLDER_YEAR         ICON                    "foldyear.ico"
+IDI_FOLDER_SOURCE       ICON                    "foldsrc.ico"
+IDI_WORKING             ICON                    "working.ico"
+IDI_NONWORKING          ICON                    "nonwork.ico"
+IDI_YEAR                ICON                    "year.ico"
+IDI_KEYBOARD            ICON                    "keyboard.ico"
+IDI_JOYSTICK            ICON                    "joystick.ico"
+IDI_CPU                 ICON                    "cpu.ico"
+IDI_SOUND               ICON                    "samples.ico"
+IDI_SOUNDTAB            ICON                    "sound.ico"
+IDI_SOURCE              ICON                    "source.ico"
+IDI_HARDDISK            ICON                    "harddisk.ico"
+IDI_DISPLAY             ICON                    "display.ico"
+IDI_CHECKMARK           ICON                    "checkmark.ico"
+IDI_HEADER_UP           ICON                    "header_up.ico"
+IDI_HEADER_DOWN         ICON                    "header_down.ico"
 
 /////////////////////////////////////////////////////////////////////////////
 //
@@ -1275,22 +1275,22 @@ END
 
 
 
-IDB_ABOUT               BITMAP                  "res\\about.bmp"
-IDB_TOOLBAR             BITMAP    "res\\toolbar.bmp"
+IDB_ABOUT               BITMAP                  "about.bmp"
+IDB_TOOLBAR             BITMAP    "toolbar.bmp"
 
 /////////////////////////////////////////////////////////////////////////////
 //
 // Cursor
 //
 
-IDC_CURSOR_HSPLIT       CURSOR                  "res\\splith.cur"
+IDC_CURSOR_HSPLIT       CURSOR                  "splith.cur"
 
 /////////////////////////////////////////////////////////////////////////////
 //
 // RT_MANIFEST
 //
 
-1                       RT_MANIFEST             "res\\mameui.manifest"
+1                       RT_MANIFEST             "mameui.manifest"
 
 /////////////////////////////////////////////////////////////////////////////
 //

--- a/src/osd/winui/mameui.rc
+++ b/src/osd/winui/mameui.rc
@@ -344,36 +344,36 @@ END
 
 // Icon with lowest ID value placed first to ensure application icon
 // remains consistent on all systems.
-IDI_MAMEUI_ICON         ICON                    "res\\mameui.ico"
-IDI_WIN_ROMS            ICON                    "res\\win_roms.ico"
-IDI_WIN_NOROMS          ICON                    "res\\win_noro.ico"
-IDI_WIN_UNKNOWN         ICON                    "res\\win_unkn.ico"
-IDI_WIN_CLONE           ICON                    "res\\win_clone.ico"
-IDI_WIN_REDX            ICON                    "res\\win_redx.ico"
-IDI_FOLDER_AVAILABLE    ICON                    "res\\foldavail.ico"
-IDI_FOLDER              ICON                    "res\\folder.ico"
-IDI_FOLDER_MANUFACTURER ICON                    "res\\foldmanu.ico"
-IDI_FOLDER_OPEN         ICON                    "res\\foldopen.ico"
-IDI_FOLDER_UNAVAILABLE  ICON                    "res\\foldunav.ico"
-IDI_FOLDER_HORIZONTAL   ICON                    "res\\horz.ico"
-IDI_FOLDER_VERTICAL     ICON                    "res\\vert.ico"
-IDI_MANUFACTURER        ICON                    "res\\manufact.ico"
-IDI_FOLDER_YEAR         ICON                    "res\\foldyear.ico"
-IDI_FOLDER_SOURCE       ICON                    "res\\foldsrc.ico"
-IDI_WORKING             ICON                    "res\\working.ico"
-IDI_NONWORKING          ICON                    "res\\nonwork.ico"
-IDI_YEAR                ICON                    "res\\year.ico"
-IDI_KEYBOARD            ICON                    "res\\keyboard.ico"
-IDI_JOYSTICK            ICON                    "res\\joystick.ico"
-IDI_CPU                 ICON                    "res\\cpu.ico"
-IDI_SOUND               ICON                    "res\\samples.ico"
-IDI_SOUNDTAB            ICON                    "res\\sound.ico"
-IDI_SOURCE              ICON                    "res\\source.ico"
-IDI_HARDDISK            ICON                    "res\\harddisk.ico"
-IDI_DISPLAY             ICON                    "res\\display.ico"
-IDI_CHECKMARK           ICON                    "res\\checkmark.ico"
-IDI_HEADER_UP           ICON                    "res\\header_up.ico"
-IDI_HEADER_DOWN         ICON                    "res\\header_down.ico"
+IDI_MAMEUI_ICON         ICON                    "mameui.ico"
+IDI_WIN_ROMS            ICON                    "win_roms.ico"
+IDI_WIN_NOROMS          ICON                    "win_noro.ico"
+IDI_WIN_UNKNOWN         ICON                    "win_unkn.ico"
+IDI_WIN_CLONE           ICON                    "win_clone.ico"
+IDI_WIN_REDX            ICON                    "win_redx.ico"
+IDI_FOLDER_AVAILABLE    ICON                    "foldavail.ico"
+IDI_FOLDER              ICON                    "folder.ico"
+IDI_FOLDER_MANUFACTURER ICON                    "foldmanu.ico"
+IDI_FOLDER_OPEN         ICON                    "foldopen.ico"
+IDI_FOLDER_UNAVAILABLE  ICON                    "foldunav.ico"
+IDI_FOLDER_HORIZONTAL   ICON                    "horz.ico"
+IDI_FOLDER_VERTICAL     ICON                    "vert.ico"
+IDI_MANUFACTURER        ICON                    "manufact.ico"
+IDI_FOLDER_YEAR         ICON                    "foldyear.ico"
+IDI_FOLDER_SOURCE       ICON                    "foldsrc.ico"
+IDI_WORKING             ICON                    "working.ico"
+IDI_NONWORKING          ICON                    "nonwork.ico"
+IDI_YEAR                ICON                    "year.ico"
+IDI_KEYBOARD            ICON                    "keyboard.ico"
+IDI_JOYSTICK            ICON                    "joystick.ico"
+IDI_CPU                 ICON                    "cpu.ico"
+IDI_SOUND               ICON                    "samples.ico"
+IDI_SOUNDTAB            ICON                    "sound.ico"
+IDI_SOURCE              ICON                    "source.ico"
+IDI_HARDDISK            ICON                    "harddisk.ico"
+IDI_DISPLAY             ICON                    "display.ico"
+IDI_CHECKMARK           ICON                    "checkmark.ico"
+IDI_HEADER_UP           ICON                    "header_up.ico"
+IDI_HEADER_DOWN         ICON                    "header_down.ico"
 
 /////////////////////////////////////////////////////////////////////////////
 //
@@ -1275,22 +1275,22 @@ END
 
 
 
-IDB_ABOUT               BITMAP                  "res\\about.bmp"
-IDB_TOOLBAR             BITMAP    "res\\toolbar.bmp"
+IDB_ABOUT               BITMAP                  "about.bmp"
+IDB_TOOLBAR             BITMAP    "toolbar.bmp"
 
 /////////////////////////////////////////////////////////////////////////////
 //
 // Cursor
 //
 
-IDC_CURSOR_HSPLIT       CURSOR                  "res\\splith.cur"
+IDC_CURSOR_HSPLIT       CURSOR                  "splith.cur"
 
 /////////////////////////////////////////////////////////////////////////////
 //
 // RT_MANIFEST
 //
 
-1                       RT_MANIFEST             "res\\mameui.manifest"
+1                       RT_MANIFEST             "mameui.manifest"
 
 /////////////////////////////////////////////////////////////////////////////
 //


### PR DESCRIPTION
Rather than changing to a forward slash (res/whatever.ico) for non-windows hosted toolchains, removing the path altogether seemed better.