### PR TITLE
Updated Alpha CPU AddressMap to support Reading of Paged VECTOR ROM. …

### DIFF
--- a/src/hbmame/drivers/mhavoc.cpp
+++ b/src/hbmame/drivers/mhavoc.cpp
@@ -26,24 +26,26 @@ void mhavoc_state::alphape_map(address_map &map)
 	map(0x0200, 0x07ff).bankrw("bank1").share("zram0");
 	map(0x0800, 0x09ff).ram();
 	map(0x0a00, 0x0fff).bankrw("bank1").share("zram1");
-	map(0x1000, 0x1000).r(FUNC(mhavoc_state::mhavoc_gamma_r));            /* Gamma Read Port */
-	map(0x1200, 0x1200).portr("IN0").nopw();    /* Alpha Input Port 0 */
-	map(0x1400, 0x141f).ram().share("colorram");    /* ColorRAM */
-	map(0x1600, 0x1600).w(FUNC(mhavoc_state::mhavoc_out_0_w));           /* Control Signals */
-	map(0x1640, 0x1640).w("avg", FUNC(avg_mhavoc_device::go_w));               /* Vector Generator GO */
+	map(0x1000, 0x1000).r(FUNC(mhavoc_state::mhavoc_gamma_r));          /* Gamma Read Port */
+	map(0x1200, 0x1200).portr("IN0").nopw();    						/* Alpha Input Port 0 */
+	map(0x1400, 0x141f).ram().share("colorram");    					/* ColorRAM */
+	map(0x1600, 0x1600).w(FUNC(mhavoc_state::mhavoc_out_0_w));         	/* Control Signals */
+	map(0x1640, 0x1640).w("avg", FUNC(avg_mhavoc_device::go_w));        /* Vector Generator GO */
 	map(0x1680, 0x1680).w("watchdog", FUNC(watchdog_timer_device::reset_w));         /* Watchdog Clear */
-	map(0x16c0, 0x16c0).w("avg", FUNC(avg_mhavoc_device::reset_w));            /* Vector Generator Reset */
-	map(0x1700, 0x1700).w(FUNC(mhavoc_state::mhavoc_alpha_irq_ack_w));   /* IRQ ack */
+	map(0x16c0, 0x16c0).w("avg", FUNC(avg_mhavoc_device::reset_w));     /* Vector Generator Reset */
+	map(0x1700, 0x1700).w(FUNC(mhavoc_state::mhavoc_alpha_irq_ack_w));  /* IRQ ack */
 	//map(0x1740, 0x1740).w(FUNC(mhavoc_state::mhavocpe_rom_banksel_w));     /* Program ROM Page Select */
 	map(0x1740, 0x1740).lw8("bnk", [this] (u8 data) { membank("bank2")->set_entry((data & 1) | ((data & 2)<<1) | ((data & 4)>>1)); });
-	map(0x1780, 0x1780).w(FUNC(mhavoc_state::mhavoc_ram_banksel_w));     /* Program RAM Page Select */
-	map(0x17c0, 0x17c0).w(FUNC(mhavoc_state::mhavoc_gamma_w));           /* Gamma Communication Write Port */
-	map(0x1800, 0x1fff).ram();                             /* Shared Beta Ram */
-	map(0x2000, 0x3fff).bankr("bank2");                        /* Paged Program ROM (32K) */
+	map(0x1780, 0x1780).w(FUNC(mhavoc_state::mhavoc_ram_banksel_w));  	/* Program RAM Page Select */
+	map(0x17c0, 0x17c0).w(FUNC(mhavoc_state::mhavoc_gamma_w));          /* Gamma Communication Write Port */
+	map(0x1800, 0x1fff).ram();                             	/* Shared Beta Ram */
+	map(0x2000, 0x3fff).bankr("bank2");                    	/* Paged Program ROM (32K) */
 	map(0x4000, 0x4fff).ram().share("vectorram").region("alpha", 0x4000);    /* Vector Generator RAM */
-	map(0x5000, 0x7fff).rom();                             /* Vector ROM */
-	map(0x8000, 0xffff).rom();                 /* Program ROM (32K) */
+	map(0x5000, 0x5fff).rom();                             	/* Vector ROM */
+	map(0x6000, 0x7fff).bankr("bank3");                    	/* Paged Vector ROM */
+	map(0x8000, 0xffff).rom();                 				/* Program ROM (32K) */
 }
+//		membank("bank3")->set_entry(m_map);
 
 void mhavoc_state::mhavocpe(machine_config &config)
 {

--- a/src/mame/drivers/mhavoc.cpp
+++ b/src/mame/drivers/mhavoc.cpp
@@ -270,22 +270,23 @@ void mhavoc_state::alpha_map(address_map &map)
 	map(0x0200, 0x07ff).bankrw("bank1").share("zram0");
 	map(0x0800, 0x09ff).ram();
 	map(0x0a00, 0x0fff).bankrw("bank1").share("zram1");
-	map(0x1000, 0x1000).r(FUNC(mhavoc_state::mhavoc_gamma_r));            /* Gamma Read Port */
-	map(0x1200, 0x1200).portr("IN0").nopw();    /* Alpha Input Port 0 */
-	map(0x1400, 0x141f).ram().share("colorram");    /* ColorRAM */
-	map(0x1600, 0x1600).w(FUNC(mhavoc_state::mhavoc_out_0_w));           /* Control Signals */
-	map(0x1640, 0x1640).w("avg", FUNC(avg_mhavoc_device::go_w));               /* Vector Generator GO */
+	map(0x1000, 0x1000).r(FUNC(mhavoc_state::mhavoc_gamma_r));          /* Gamma Read Port */
+	map(0x1200, 0x1200).portr("IN0").nopw();    						/* Alpha Input Port 0 */
+	map(0x1400, 0x141f).ram().share("colorram");    					/* ColorRAM */
+	map(0x1600, 0x1600).w(FUNC(mhavoc_state::mhavoc_out_0_w));          /* Control Signals */
+	map(0x1640, 0x1640).w("avg", FUNC(avg_mhavoc_device::go_w));        /* Vector Generator GO */
 	map(0x1680, 0x1680).w("watchdog", FUNC(watchdog_timer_device::reset_w));         /* Watchdog Clear */
-	map(0x16c0, 0x16c0).w("avg", FUNC(avg_mhavoc_device::reset_w));            /* Vector Generator Reset */
-	map(0x1700, 0x1700).w(FUNC(mhavoc_state::mhavoc_alpha_irq_ack_w));   /* IRQ ack */
-	map(0x1740, 0x1740).w(FUNC(mhavoc_state::mhavoc_rom_banksel_w));     /* Program ROM Page Select */
-	map(0x1780, 0x1780).w(FUNC(mhavoc_state::mhavoc_ram_banksel_w));     /* Program RAM Page Select */
-	map(0x17c0, 0x17c0).w(FUNC(mhavoc_state::mhavoc_gamma_w));           /* Gamma Communication Write Port */
-	map(0x1800, 0x1fff).ram();                             /* Shared Beta Ram */
-	map(0x2000, 0x3fff).bankr("bank2");                        /* Paged Program ROM (32K) */
+	map(0x16c0, 0x16c0).w("avg", FUNC(avg_mhavoc_device::reset_w));     /* Vector Generator Reset */
+	map(0x1700, 0x1700).w(FUNC(mhavoc_state::mhavoc_alpha_irq_ack_w));	/* IRQ ack */
+	map(0x1740, 0x1740).w(FUNC(mhavoc_state::mhavoc_rom_banksel_w));    /* Program ROM Page Select */
+	map(0x1780, 0x1780).w(FUNC(mhavoc_state::mhavoc_ram_banksel_w));    /* Program RAM Page Select */
+	map(0x17c0, 0x17c0).w(FUNC(mhavoc_state::mhavoc_gamma_w));          /* Gamma Communication Write Port */
+	map(0x1800, 0x1fff).ram();                             	/* Shared Beta Ram */
+	map(0x2000, 0x3fff).bankr("bank2");                     /* Paged Program ROM (32K) */
 	map(0x4000, 0x4fff).ram().share("vectorram").region("alpha", 0x4000);    /* Vector Generator RAM */
-	map(0x5000, 0x7fff).rom();                             /* Vector ROM */
-	map(0x8000, 0xffff).rom();                 /* Program ROM (32K) */
+	map(0x5000, 0x5fff).rom();                             	/* Vector ROM */
+	map(0x6000, 0x7fff).bankr("bank3");                    	/* Paged Vector ROM */
+	map(0x8000, 0xffff).rom();                 				/* Program ROM (32K) */
 }
 
 

--- a/src/mame/machine/mhavoc.cpp
+++ b/src/mame/machine/mhavoc.cpp
@@ -90,6 +90,7 @@ void mhavoc_state::machine_reset()
 	membank("bank1")->configure_entry(0, m_zram0);
 	membank("bank1")->configure_entry(1, m_zram1);
 	membank("bank2")->configure_entries(0, 8, memregion("alpha")->base() + 0x10000, 0x2000);
+	membank("bank3")->configure_entries(0, 4, memregion("avgdvg")->base(), 0x2000);
 
 	/* reset RAM/ROM banks to 0 */
 	mhavoc_ram_banksel_w(space, 0, 0);
@@ -151,7 +152,6 @@ READ8_MEMBER(mhavoc_state::mhavoc_alpha_r)
 	m_alpha_xmtd = 0;
 	return m_alpha_data;
 }
-
 
 
 /*************************************

--- a/src/mame/video/avgdvg.cpp
+++ b/src/mame/video/avgdvg.cpp
@@ -774,9 +774,12 @@ int avg_mhavoc_device::handler_6() // mhavoc_strobe2
 		else
 		{
 			m_color = m_dvy & 0xf;
-
 			m_intensity = (m_dvy >> 4) & 0xf;
 			m_map = (m_dvy >> 8) & 0x3;
+			
+			//this is required so that the Alpha CPU can read active paged VROM
+			machine().root_device().membank("bank3")->set_entry(m_map);
+		
 			if (m_dvy & 0x800)
 			{
 				m_enspkl = 1;


### PR DESCRIPTION
…In the original code, the Paged VROM was mapped as a static block which was never loaded. This didn't effect gameplay because the Vector Generator still had the Paged VROM, but it did prevent the Self Test (executed on Alpha CPU) from being able to read the paged VROM and hence it would always show as having a bad CSUM for the Paged VROM locations in the game self test. This checkin solves this problem for both the Original mhavoc drivers and the new updated mhavocpe/mhavocpex driver.