### PR TITLE
8080bw: comment out unused superinv

### DIFF
--- a/src/mame/drivers/8080bw.cpp
+++ b/src/mame/drivers/8080bw.cpp
@@ -1350,6 +1350,7 @@ INPUT_PORTS_END
 /*                                                     */
 /*******************************************************/
 
+#if 0
 static INPUT_PORTS_START( superinv )
 	PORT_INCLUDE( sicv )
 
@@ -1364,8 +1365,6 @@ static INPUT_PORTS_START( superinv )
 	PORT_DIPSETTING(    0x00, "2500" )
 	PORT_DIPUNKNOWN_DIPLOC( 0x80, 0x00, "SW1:8" )
 INPUT_PORTS_END
-
-#if 0
 
 /*******************************************************/
 /*                                                     */


### PR DESCRIPTION
The game that uses this input port definition was already commented out in a previous commit, and clang will refuse to compile with this unused static function in place:

```
Compiling src/mame/drivers/8080bw.cpp...
../../../../../src/mame/drivers/8080bw.cpp:1353:8: error: unused function 'construct_ioport_superinv' [-Werror,-Wunused-function]
static INPUT_PORTS_START( superinv )
       ^
In file included from ../../../../../src/mame/drivers/8080bw.cpp:1:
In file included from ../../../../../src/emu/emu.h:58:
/Users/vlcice/github/hbmame/build/projects/sdl/mame/gmake-osx-clang/../../../../../src/emu/ioport.h:1567:16: note: expanded from macro 'INPUT_PORTS_START'
ATTR_COLD void INPUT_PORTS_NAME(_name)(device_t &owner, ioport_list &portlist, std::string &errorbuf) \
               ^
/Users/vlcice/github/hbmame/build/projects/sdl/mame/gmake-osx-clang/../../../../../src/emu/ioport.h:1563:33: note: expanded from macro 'INPUT_PORTS_NAME'
#define INPUT_PORTS_NAME(_name) construct_ioport_##_name
                                ^
<scratch space>:104:1: note: expanded from here
construct_ioport_superinv
^
1 error generated.
make[2]: *** [../../../../osx_clang/obj/x64/Release/src/mame/drivers/8080bw.o] Error 1
make[1]: *** [midw8080] Error 2
make: *** [macosx_arm64_clang] Error 2
```