### PR TITLE
Fix build with Clang 19

### DIFF
--- a/3rdparty/sol2/sol/sol.hpp
+++ b/3rdparty/sol2/sol/sol.hpp
@@ -6051,12 +6051,9 @@ namespace sol {
 		/// one.
 		///
 		/// \group emplace
-		template <class... Args>
-		T& emplace(Args&&... args) noexcept {
-			static_assert(std::is_constructible<T, Args&&...>::value, "T must be constructible with Args");
-
-			*this = nullopt;
-			this->construct(std::forward<Args>(args)...);
+		T& emplace(T& arg) noexcept {
+			m_value = &arg;
+			return **this;
 		}
 
 		/// Swaps this optional with the other.

--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -996,6 +996,7 @@ end
 -- warnings only applicable to C++ compiles
 	buildoptions_cpp {
 		"-Woverloaded-virtual",
+		"-Wvla",
 	}
 
 if _OPTIONS["SANITIZE"] then

--- a/src/osd/modules/font/font_sdl.cpp
+++ b/src/osd/modules/font/font_sdl.cpp
@@ -198,9 +198,8 @@ osd_font_sdl::TTF_Font_ptr osd_font_sdl::TTF_OpenFont_Magic(std::string const &n
 		unsigned char const ttf_magic[] = { 0x00, 0x01, 0x00, 0x00, 0x00 };
 		unsigned char const ttc1_magic[] = { 0x74, 0x74, 0x63, 0x66, 0x00, 0x01, 0x00, 0x00 };
 		unsigned char const ttc2_magic[] = { 0x74, 0x74, 0x63, 0x66, 0x00, 0x02, 0x00, 0x00 };
-		auto buffer_size = std::max({ sizeof(ttf_magic), sizeof(ttc1_magic), sizeof(ttc2_magic) });
-		unsigned char buffer[buffer_size];
-		auto const bytes_read = file.read(buffer, buffer_size);
+		unsigned char buffer[8];
+		auto const bytes_read = file.read(buffer, std::size(buffer));
 		file.close();
 
 		if (((bytes_read >= sizeof(ttf_magic)) && !std::memcmp(buffer, ttf_magic, sizeof(ttf_magic))) ||

--- a/src/osd/modules/input/input_xinput.cpp
+++ b/src/osd/modules/input/input_xinput.cpp
@@ -14,9 +14,6 @@
 
 #include "input_xinput.h"
 
-// standard windows headers
-#include <windows.h>
-
 
 #define XINPUT_LIBRARIES { "xinput1_4.dll", "xinput9_1_0.dll" }
 

--- a/src/tools/chdman.cpp
+++ b/src/tools/chdman.cpp
@@ -13,6 +13,7 @@
 #include "bitmap.h"
 #include "cdrom.h"
 #include "corefile.h"
+#include "coretmpl.h"
 #include "hashing.h"
 #include "md5.h"
 #include "strformat.h"
@@ -516,8 +517,8 @@ public:
 				uint32_t samples = (uint64_t(m_info.rate) * uint64_t(effframe + 1) * uint64_t(1000000) + m_info.fps_times_1million - 1) / uint64_t(m_info.fps_times_1million) - first_sample;
 
 				// loop over channels and read the samples
-				int channels = unsigned((std::min<std::size_t>)(m_info.channels, std::size(m_audio)));
-				int16_t *samplesptr[std::size(m_audio)];
+ 				int channels = unsigned(std::min<std::size_t>(m_info.channels, std::size(m_audio)));
+ 				EQUIVALENT_ARRAY(m_audio, int16_t *) samplesptr;
 				for (int chnum = 0; chnum < channels; chnum++)
 				{
 					// read the sound samples


### PR DESCRIPTION
Nixpkgs recently bumped the version of Clang/LLVM it uses on macOS, causing my `hbmame` derivation to stop building. I've [ported over](https://github.com/Rhys-T/nur-packages/blob/a11080c43432349d571cd8696ca784ba98b1a172/pkgs/mame/hbmame.nix#L35-L49) the relevant changes I could find from upstream MAME. [They get it building again](https://github.com/Rhys-T/nur-packages/actions/runs/12501045313/job/34878002813), and the resulting program seems to run correctly, but I haven't done extensive testing on it. In particular, I cut out several parts of the second commit that seem to apply to code that just doesn't exist in HBMAME. That commit also touches Windows-specific code, which I am not currently able to test. 