### PR TITLE
Fix build with Clang 19 - take 2

### DIFF
--- a/3rdparty/sol2/sol/sol.hpp
+++ b/3rdparty/sol2/sol/sol.hpp
@@ -6051,12 +6051,9 @@ namespace sol {
 		/// one.
 		///
 		/// \group emplace
-		template <class... Args>
-		T& emplace(Args&&... args) noexcept {
-			static_assert(std::is_constructible<T, Args&&...>::value, "T must be constructible with Args");
-
-			*this = nullopt;
-			this->construct(std::forward<Args>(args)...);
+		T& emplace(T& arg) noexcept {
+			m_value = &arg;
+			return **this;
 		}
 
 		/// Swaps this optional with the other.

--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -1068,6 +1068,11 @@ end
 					"-Wno-bitwise-instead-of-logical", -- clang 14.0 complains about &, | on bools in asmjit
 				}
 			end
+			if version >= 180100 then
+				buildoptions {
+					"-Wno-vla-cxx-extension", -- clang 18.1 complains about variable-length arrays in C++ -- HBMAME
+				}
+			end
 		else
 			if version < 70000 then
 				print("GCC version 7.0 or later needed")


### PR DESCRIPTION
Alternate version of #25. This one just brings in the `sol2` update from upstream MAME, and disables Clang 18.1+'s warnings/errors about using variable-length arrays in C++ (instead of removing the VLAs like #25 did).