### PR TITLE
Fix build with Clang 21

### DIFF
--- a/src/hbmame/drivers/galactic.cpp
+++ b/src/hbmame/drivers/galactic.cpp
@@ -57,8 +57,6 @@ public:
 private:
 
 	bool m_flip_screen = false;
-	bool m_screen_red = false;
-	bool m_sound_enabled = false;
 	u8 m_port_1_last_extra = 0U;
 	u8 m_port_2_last_extra = 0U;
 	emu_timer   *m_interrupt_timer = nullptr;

--- a/src/hbmame/drivers/galaxian.cpp
+++ b/src/hbmame/drivers/galaxian.cpp
@@ -1014,7 +1014,6 @@ private:
 	void gfxbank_w(offs_t, uint8_t);
 	void rombank_w(offs_t, uint8_t);
 	uint16_t m_oldprom = 0xff;
-	uint8_t m_oldgfx = 0xff;
 	uint8_t m_rom_bank = 0;
 };
 


### PR DESCRIPTION
Builds with current Apple clang (Xcode 21) fail out of the box: clang 21's `-Wunused-private-field` now also flags fields that have initializers, and the default `-Werror` turns that into hard errors in two HBMAME drivers. GCC doesn't have this warning, and older clang ignored fields with initializers, so other toolchains never see it.

- `galaxian.cpp`: `gmultib_state::m_oldgfx` — its only reference was the `#if 0` gfx-dirty block in `gfxbank_w`, which was deleted when gmultic was added.
- `galactic.cpp`: `sm_state::m_screen_red` and `m_sound_enabled` — never referenced; carried over from the mw8080bw state class when the driver (then spacmiss.c) was first imported.

Removes the three fields. No functional change; none of them are registered for save states.

Verified on macOS arm64 with Apple clang 21.0.0: before the change, a default build (no `NOWERROR`) errors on exactly these three fields; after it, both drivers compile cleanly and the hbmame binary links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)